### PR TITLE
Feature: detail 페이지 구현

### DIFF
--- a/app/[type]/[id]/page.tsx
+++ b/app/[type]/[id]/page.tsx
@@ -1,0 +1,39 @@
+import PlayButton from '@/components/common/PlayButton';
+import { getDetail } from '@/services/tmdb';
+import { MovieDetail, TVDetail } from '@/types/movie.types';
+import Image from 'next/image';
+
+function isMovieDetail(data: MovieDetail | TVDetail): data is MovieDetail {
+	return 'title' in data;
+}
+
+export default async function Page({ params }: { params: Promise<{ type: 'tv' | 'movie'; id: string }> }) {
+	const { type, id } = await params;
+
+	const response = await getDetail(`/${type}/${id}`);
+	if (!response) return null;
+
+	const title = isMovieDetail(response) ? response.title : response.name;
+
+	return (
+		<div>
+			<div
+				className="relative w-full aspect-5/7
+          before:content-[''] before:absolute before:left-0 before:top-0 before:right-0 before:bottom-0
+          before:z-10 before:bg-linear-(--movie-bg-gradient)"
+			>
+				<Image
+					className="object-cover"
+					src={`https://image.tmdb.org/t/p/w500${response.poster_path}`}
+					alt={`${title} 포스터`}
+					fill
+				/>
+			</div>
+			<div className="px-6 pt-4 pb-40">
+				<PlayButton />
+				<h3 className="text-white header1 mt-6 mb-4">{title}</h3>
+				<div className="text-white body3">{response.overview}</div>
+			</div>
+		</div>
+	);
+}

--- a/app/[type]/[id]/page.tsx
+++ b/app/[type]/[id]/page.tsx
@@ -19,8 +19,8 @@ export default async function Page({ params }: { params: Promise<{ type: 'tv' | 
 		<div>
 			<div
 				className="relative w-full aspect-5/7
-          before:content-[''] before:absolute before:left-0 before:top-0 before:right-0 before:bottom-0
-          before:z-10 before:bg-linear-(--movie-bg-gradient)"
+					before:content-[''] before:absolute before:left-0 before:top-0 before:right-0 before:bottom-0
+					before:z-10 before:bg-linear-(--movie-bg-gradient)"
 			>
 				<Image
 					className="object-cover"

--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -10,7 +10,9 @@ export default async function Home() {
 			<HomeLNB />
 			<section>
 				<Top10Banner />
-				<section className={'w-full h-fit py-4 px-12 flex justify-between items-center'}>
+				<section
+					className={'w-full h-fit py-4 px-4 min-[440px]:px-12 grid grid-cols-[100px_1fr_100px] place-items-center'}
+				>
 					<BannerOption option="plus" />
 					<PlayButton />
 					<BannerOption option="info" />

--- a/components/common/PlayButton.tsx
+++ b/components/common/PlayButton.tsx
@@ -2,7 +2,10 @@ import { PlayIcon } from '@/icons/Play';
 
 const PlayButton = () => {
 	return (
-		<button className="w-fit h-fit py-2 px-4 bg-gray-100 text-black headline2-medium rounded-sm flex items-center justify-center gap-2">
+		<button
+			className="w-full h-fit py-2 px-4 flex items-center justify-center gap-2
+			bg-gray-100 text-black headline2-medium rounded-sm"
+		>
 			<PlayIcon />
 			Play
 		</button>

--- a/components/features/home/Banner/Top10Banner.tsx
+++ b/components/features/home/Banner/Top10Banner.tsx
@@ -10,6 +10,7 @@ import 'swiper/css';
 import { getTrendingMovies } from '@/services/tmdb';
 
 import Top10Chip from './Top10Chip';
+import Link from 'next/link';
 
 interface TrendingMovie {
 	adult: boolean;
@@ -47,7 +48,7 @@ export default function Top10Banner() {
 	}, []);
 
 	return (
-		<ul className="w-full h-fit aspect-[5/7] relative">
+		<ul className="w-full aspect-[5/7] relative">
 			{top10Movies.length > 0 && (
 				<Swiper
 					autoplay={{ delay: 6000 }}
@@ -58,19 +59,21 @@ export default function Top10Banner() {
 						setSwiperIndex(swiper.realIndex + 1); // 초기 인덱스 설정
 					}}
 					onSlideChange={(swiper) => setSwiperIndex(swiper.realIndex + 1)}
-					className="w-full h-full overflow-x-hidden"
+					className="w-full h-full before:absolute
+						before:left-0 before:top-0 before:right-0 before:bottom-0
+						before:z-10 before:bg-linear-(--movie-bg-gradient) before:pointer-events-none"
 				>
 					{top10Movies.map((movie, index) => (
 						<SwiperSlide key={movie.id} className="w-full h-full">
-							<li className="w-full h-full aspect-5/7 relative">
-								<div className="w-full h-full absolute top-0 left-0 z-5 opacity-20 poster-backdrop"></div>
-								<Image
-									src={`https://image.tmdb.org/t/p/original${movie.poster_path}`}
-									alt={movie.title}
-									fill
-									sizes="(max-width: 512px) 100vw"
-									priority={index === 0}
-								/>
+							<li className="w-full h-full">
+								<Link href={`/movie/${movie.id}`} className="relative w-full h-full block">
+									<Image
+										src={`https://image.tmdb.org/t/p/original${movie.poster_path}`}
+										alt={movie.title}
+										fill
+										priority={index === 0}
+									/>
+								</Link>
 							</li>
 						</SwiperSlide>
 					))}

--- a/components/features/home/MovieList/CategorizedMovieList.tsx
+++ b/components/features/home/MovieList/CategorizedMovieList.tsx
@@ -1,10 +1,19 @@
 import Image from 'next/image';
+import Link from 'next/link';
 
 import clsx from 'clsx';
 
 import { Movie } from '@/types/movie.types';
 
-export default function CategorizedMovieList({ category, movies }: { category: string; movies: Movie[] | null }) {
+export default function CategorizedMovieList({
+	category,
+	movies,
+	type,
+}: {
+	category: string;
+	movies: Movie[] | null;
+	type: string;
+}) {
 	const isOriginal = category === 'Netflix Originals';
 
 	if (!movies) return null;
@@ -14,17 +23,20 @@ export default function CategorizedMovieList({ category, movies }: { category: s
 			<h3 className="headline2">{category}</h3>
 			<div className="relative w-full h-fit overflow-x-scroll no-scrollbar flex gap-2 pr-4">
 				{movies.map((movie, i) => (
-					<Image
+					<Link
+						className={clsx('relative shrink-0 ', isOriginal ? 'w-45 h-60' : 'w-30 h-40')}
+						href={`/${type}/${movie.id}`}
 						key={i}
-						unoptimized
-						src={'https://image.tmdb.org/t/p/w500' + movie.poster_path}
-						alt={`${movie.title} poster`}
-						width={isOriginal ? 180 : 120}
-						height={isOriginal ? 240 : 160}
-						className={clsx('bg-gray-200 object-cover', isOriginal ? 'rounded-[0.125rem]' : 'rounded-[0.0625rem]')}
-						style={{ aspectRatio: '3/4' }}
-						priority={i < 3 ? true : false}
-					/>
+					>
+						<Image
+							unoptimized
+							fill
+							src={'https://image.tmdb.org/t/p/w500' + movie.poster_path}
+							alt={`${movie.title} poster`}
+							className={clsx('bg-gray-200 object-cover', isOriginal ? 'rounded-[0.125rem]' : 'rounded-[0.0625rem]')}
+							priority={i < 3 ? true : false}
+						/>
+					</Link>
 				))}
 			</div>
 		</div>

--- a/components/features/home/MovieList/PreviewList.tsx
+++ b/components/features/home/MovieList/PreviewList.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image';
 
 import { getMoviesApi } from '@/services/tmdb';
+import Link from 'next/link';
 
 export default async function PreviewList() {
 	const response = await getMoviesApi('/movie/now_playing');
@@ -11,16 +12,17 @@ export default async function PreviewList() {
 			<h3 className="headline1">Previews</h3>
 			<div className="relative w-full h-fit overflow-x-scroll no-scrollbar flex gap-2 pr-4">
 				{previews.map((preview, i) => (
-					<Image
-						unoptimized
-						src={'https://image.tmdb.org/t/p/w500' + preview.poster_path}
-						alt={`${preview.title} poster`}
-						width={100}
-						height={100}
-						className="bg-gray-200 object-cover w-25 h-25 aspect-square rounded-full"
-						key={i}
-						priority={i < 3 ? true : false}
-					/>
+					<Link className="relative shrink-0" key={i} href={`/movie/${preview.id}`}>
+						<Image
+							unoptimized
+							src={'https://image.tmdb.org/t/p/w500' + preview.poster_path}
+							alt={`${preview.title} poster`}
+							width={100}
+							height={100}
+							className="bg-gray-200 object-cover w-25 h-25 aspect-square rounded-full"
+							priority={i < 3 ? true : false}
+						/>
+					</Link>
 				))}
 			</div>
 		</div>

--- a/components/features/home/MovieList/index.tsx
+++ b/components/features/home/MovieList/index.tsx
@@ -12,7 +12,12 @@ export default async function MovieList() {
 		<div className="flex flex-col gap-5 pb-21">
 			<PreviewList />
 			{responses.map((response, i) => (
-				<CategorizedMovieList key={i} category={categoryEndpointMap[i].category} movies={response?.results ?? null} />
+				<CategorizedMovieList
+					key={i}
+					category={categoryEndpointMap[i].category}
+					movies={response?.results ?? null}
+					type={categoryEndpointMap[i].type}
+				/>
 			))}
 		</div>
 	);

--- a/constants/categoryEndpointMap.ts
+++ b/constants/categoryEndpointMap.ts
@@ -2,25 +2,31 @@ export const categoryEndpointMap = [
 	{
 		category: "Today's Trend Movie",
 		endpoint: '/trending/movie/day?language=en-US',
+		type: 'movie',
 	},
 	{
 		category: 'Now Playing',
 		endpoint: '/movie/now_playing',
+		type: 'movie',
 	},
 	{
 		category: 'Top Rated',
 		endpoint: '/movie/top_rated',
+		type: 'movie',
 	},
 	{
 		category: 'Upcomming',
 		endpoint: '/movie/upcoming',
+		type: 'movie',
 	},
 	{
 		category: "Todays's Trand TV",
 		endpoint: '/trending/tv/day?language=en-US',
+		type: 'tv',
 	},
 	{
 		category: 'Popular',
 		endpoint: '/movie/popular',
+		type: 'movie',
 	},
 ];

--- a/services/tmdb.ts
+++ b/services/tmdb.ts
@@ -1,5 +1,5 @@
 import { fetcher } from '@/lib/fetcher';
-import { TMDBResponse } from '@/types/movie.types';
+import { MovieDetail, TMDBResponse, TVDetail } from '@/types/movie.types';
 
 export const getTrendingMovies = async () => {
 	try {
@@ -20,6 +20,16 @@ export async function getMoviesApi(endpoint: string): Promise<TMDBResponse | nul
 		return movieData;
 	} catch (error) {
 		console.error('Error fetching movie data:', error);
+		return null;
+	}
+}
+
+export async function getDetail(endpoint: string): Promise<MovieDetail | TVDetail | null> {
+	try {
+		const detailData = await fetcher(endpoint);
+		return detailData;
+	} catch (error) {
+		console.error('Error fetching detail data:', error);
 		return null;
 	}
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -21,8 +21,6 @@
 	--text-20: 20px;
 	--text-24: 24px;
 	--text-28: 28px;
-
-	--mobile-width: 375px;
 }
 
 @layer utilities {
@@ -60,13 +58,6 @@
 
 	.caption {
 		@apply font-netflix-sans text-10 font-normal leading-normal;
-	}
-
-	.poster-backdrop {
-		background:
-			linear-gradient(0deg, rgba(0, 0, 0, 0.2) 0%, rgba(0, 0, 0, 0.2) 100%),
-			linear-gradient(180deg, rgba(0, 0, 0, 0.45) 0%, rgba(0, 0, 0, 0) 87.26%, #000 100%),
-			var(--color-gray-200) 50% / cover no-repeat;
 	}
 
 	.swiper-wrapper {

--- a/types/movie.types.ts
+++ b/types/movie.types.ts
@@ -17,3 +17,15 @@ export interface Movie {
 	vote_average: number;
 	vote_count: number;
 }
+
+export interface MovieDetail {
+	title: string;
+	overview: string;
+	poster_path: string;
+}
+
+export interface TVDetail {
+	name: string;
+	overview: string;
+	poster_path: string;
+}


### PR DESCRIPTION
## 작업 내용
**디테일 페이지 구현**
- tv와 movie에 따라 다른 엔드포인트로 api 요청을 보내야 해서 `/[type]/[id]`로 type까지 동적 라우팅으로 받도록 구현했습니다.
- movie-list, previews, banner 모두 Link 컴포넌트를 사용해 포스터 클릭 시 디테일 페이지로 라우팅하도록 했습니다.

**수정 사항**
디테일 페이지와 기존 컴포넌트들을 엮다 보니 철흥 님 코드를 더 면밀히 볼 수 있었는데요! 그러면서 조금 수정하게 된 부분이 있습니다.
- banner 컴포넌트에 Link 컴포넌트를 추가하면서 전반적으로 width, height 속성 관련 충돌 가능성을 확인했습니다: `h-fit`과 `aspect-5/7`이 같이 있는 경우, `h-fit` 바로 아래 요소에 `h-full`이 있는 경우 등. 따라서 최상위 div에서 `aspect-5/7`을 걸고 내부 요소들은 모두 `h-full`로 통일하는 방식으로 수정했습니다.
- banner 이미지 앞에 `poster-backdrop`와 `opacity` 클래스를 설정한 div를 렌더링하고 있더라고요. div가 css적으로만 유의미한 요소이기 때문에 before 가상요소를 사용해 수정하면서, poster-backdrop 클래스는 사용할 수 없어 기존에 만들어 둔 `bg-linear-(--movie-bg-gradient)`를 사용했습니다. 또 swiper 전체에 before를 거는 방식으로 매 슬라이드마다 gradient 요소가 나타나는 대신 한 번만 렌더링되도록 수정했습니다!
- play button을 `/components/common`에 두신 걸로 보아 디테일 페이지에서도 공통으로 사용하고자 하신 것 같았는데요, `w-fix` 클래스가 적용돼 있어 디테일 페이지에서의 사용에 문제가 있었습니다. play button의 width를 full로 변경하고, home에서 grid를 사용해 적절한 간격을 유지하도록 수정했습니다.